### PR TITLE
Clojure: remove boxing overhead, prefer primitive Longs

### DIFF
--- a/clojure/tak.clj
+++ b/clojure/tak.clj
@@ -1,6 +1,6 @@
 (ns tak)
 
-(defn tak [x y z]
+(defn tak ^long [^long x ^long y ^long z]
   (if (< y x)
     (tak
       (tak (dec x) y z)
@@ -8,8 +8,8 @@
       (tak (dec z) x y))
     z))
 
-(def args *command-line-args*)
-(let [x (Integer/parseInt (nth args 0))
-      y (Integer/parseInt (nth args 1))
-      z (Integer/parseInt (nth args 2))]
+(let [args *command-line-args*
+      x (Long/parseLong (nth args 0))
+      y (Long/parseLong (nth args 1))
+      z (Long/parseLong (nth args 2))]
   (println (tak x y z)))


### PR DESCRIPTION
~2x faster via removing boxing.

```
❯ time clojure -M tak.clj 48 20 12
13
clojure -M tak.clj 48 20 12  2.38s user 0.09s system 112% cpu 2.184 total
```

vs 

```
❯ time clojure -M tak-old.clj 48 20 12
13
clojure -M tak-old.clj 48 20 12  4.89s user 0.10s system 105% cpu 4.710 total
``` 


